### PR TITLE
rxjs must be a peer dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js :
  - stable
 install:
  - npm install
+ - npm install rxjs@6.2.0
 script:
  - npm test
  

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   },
   "author": "Angel Nikolov <darkysharky@gmail.com>",
   "license": "ISC",
-  "dependencies": {
-    "@types/jasmine": "^2.8.6",
-    "jasmine": "^3.1.0",
+  "peerDependencies": {
     "rxjs": "6.2.0"
   },
   "devDependencies": {
+    "@types/jasmine": "^2.8.6",
+    "jasmine": "^3.1.0",
     "karma": "^2.0.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-commonjs": "^1.0.0",


### PR DESCRIPTION
Hi,

I think it would be better if `@types/jasmine` and `jasmine` were in `devDependencies` and `rxjs` were in `peerDependencies` (so it does not install those packages into `./node_modules/ngx-cacheable/node_modules` if they are missing).