### PR TITLE
Added more global configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,53 @@ export interface ICacheConfig {
 }
 ```
 
+## Global Configuration
+Some of the local cache config options (passed to specific decorators) can also be used as global ones. All the local configurations will of course take precedence over the global ones.
+Here are all the possible global configurations:
+```ts
+  /**
+   * whether should use a sliding expiration strategy on caches
+   * this will reset the cache created property and keep the cache alive for @param maxAge milliseconds more
+   */
+  slidingExpiration: boolean;
+  /**
+   * max cacheCount for different parameters
+   * @description maximum allowed unique caches (same parameters)
+   */
+  maxCacheCount: number;
+  /**
+   * @description request cache resolver which will get old and new paramaters passed to and based on those
+   * will figure out if we need to bail out of cache or not
+   */
+  cacheResolver: ICacheRequestResolver;
+  /**
+   * @description cache hasher which will be called to hash the parameters into a cache key
+   */
+  cacheHasher: ICacheHasher;
+  /**
+   * @description cache decider that will figure out if the response should be cached or not, based on it
+   */
+  shouldCacheDecider: IShouldCacheDecider;
+  /**
+   * maxAge of cache in milliseconds
+   * @description if time between method calls is larger - we bail out of cache
+   */
+  maxAge: number;
+  /**
+   * @description storage strategy to be used for setting, evicting and updating cache.
+   */
+  storageStrategy: new () => IStorageStrategy | IAsyncStorageStrategy;
+  /**
+   * @description global cache key which will be used to namespace the cache.
+   * for example, it will be used in the DOMStorageStrategy for now.
+   */
+  globalCacheKey: string;
+  /**
+   * @description a custom promise implementation. For example, if you use angularjs, you might like to provide $q's promise here change detection still works properly.
+   */
+  promiseImplementation: (() => PromiseConstructorLike) | PromiseConstructorLike;
+```
+
 ## Examples
 ### Cache Busting
 You can achieve it by decorating the cache busting method with the CacheBuster decorator. So you can have one method for fetching and caching data and another, to remove the cache. This is useful when for example you want to add an item to a list and refresh that list afterwards.

--- a/cacheable.decorator.ts
+++ b/cacheable.decorator.ts
@@ -53,17 +53,17 @@ export function Cacheable(cacheConfig: IObservableCacheConfig = {}) {
         /**
          * check if maxAge is passed and cache has actually expired
          */
-        if (cacheConfig.maxAge && _foundCachePair && _foundCachePair.created) {
+        if ((cacheConfig.maxAge || GlobalCacheConfig.maxAge) && _foundCachePair && _foundCachePair.created) {
           if (
             new Date().getTime() - new Date(_foundCachePair.created).getTime() >
-            cacheConfig.maxAge
+            (cacheConfig.maxAge || GlobalCacheConfig.maxAge)
           ) {
             /**
              * cache duration has expired - remove it from the cachePairs array
              */
             storageStrategy.removeAtIndex(cachePairs.indexOf(_foundCachePair), cacheKey);
             _foundCachePair = null;
-          } else if (cacheConfig.slidingExpiration) {
+          } else if (cacheConfig.slidingExpiration || GlobalCacheConfig.slidingExpiration) {
             /**
              * renew cache duration
              */
@@ -103,17 +103,17 @@ export function Cacheable(cacheConfig: IObservableCacheConfig = {}) {
                 cacheConfig.shouldCacheDecider(response)
               ) {
                 if (
-                  !cacheConfig.maxCacheCount ||
-                  cacheConfig.maxCacheCount === 1 ||
-                  (cacheConfig.maxCacheCount &&
-                    cacheConfig.maxCacheCount < cachePairs.length + 1)
+                  !(cacheConfig.maxCacheCount || GlobalCacheConfig.maxCacheCount) ||
+                  (cacheConfig.maxCacheCount || GlobalCacheConfig.maxCacheCount) === 1 ||
+                  ((cacheConfig.maxCacheCount || GlobalCacheConfig.maxCacheCount) &&
+                    (cacheConfig.maxCacheCount || GlobalCacheConfig.maxCacheCount) < cachePairs.length + 1)
                 ) {
                   storageStrategy.removeAtIndex(0, cacheKey);
                 }
                 storageStrategy.add({
                   parameters: cacheParameters,
                   response,
-                  created: cacheConfig.maxAge ? new Date() : null
+                  created: (cacheConfig.maxAge || GlobalCacheConfig.maxAge) ? new Date() : null
                 }, cacheKey);
               }
             }),

--- a/common/index.ts
+++ b/common/index.ts
@@ -26,10 +26,13 @@ export type ICacheable<T> = (...args: Array<any>) => T;
 export { ICacheBusterConfig, ICacheConfig, ICachePair };
 
 export const GlobalCacheConfig: {
-  cacheResolver?: ICacheResolver,
-  cacheHasher?: ICacheHasher,
-  storageStrategy: new () => IStorageStrategy | IAsyncStorageStrategy,
-  globalCacheKey: string,
+  maxAge?: number;
+  slidingExpiration?: boolean;
+  maxCacheCount?: number;
+  cacheResolver?: ICacheResolver;
+  cacheHasher?: ICacheHasher;
+  storageStrategy: new () => IStorageStrategy | IAsyncStorageStrategy;
+  globalCacheKey: string;
   promiseImplementation: (() => PromiseConstructorLike) | PromiseConstructorLike;
 } = {
   storageStrategy: InMemoryStorageStrategy,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,9 @@ module.exports = function (config) {
       './promise.cache-buster.decorator.ts',
       './promise.cacheable.decorator.ts',
       './specs/observable-cacheable.decorator.spec.ts',
-      './specs/promise-cacheable.decorator.spec.ts'
+      './specs/promise-cacheable.decorator.spec.ts',
+      './specs/cat.ts',
+      './specs/service.interface.ts',
     ],
     preprocessors: {
       '**/*.ts': 'karma-typescript'

--- a/promise.cacheable.decorator.ts
+++ b/promise.cacheable.decorator.ts
@@ -17,17 +17,17 @@ const getResponse = (oldMethod: Function, cacheKey: string, cacheConfig: ICacheC
   /**
    * check if maxAge is passed and cache has actually expired
    */
-  if (cacheConfig.maxAge && _foundCachePair && _foundCachePair.created) {
+  if ((cacheConfig.maxAge || GlobalCacheConfig.maxAge) && _foundCachePair && _foundCachePair.created) {
     if (
       new Date().getTime() - new Date(_foundCachePair.created).getTime() >
-      cacheConfig.maxAge
+      (cacheConfig.maxAge || GlobalCacheConfig.maxAge)
     ) {
       /**
        * cache duration has expired - remove it from the cachePairs array
        */
       storageStrategy.removeAtIndex(cachePairs.indexOf(_foundCachePair), cacheKey);
       _foundCachePair = null;
-    } else if (cacheConfig.slidingExpiration) {
+    } else if (cacheConfig.slidingExpiration || GlobalCacheConfig.slidingExpiration) {
       /**
        * renew cache duration
        */
@@ -54,17 +54,17 @@ const getResponse = (oldMethod: Function, cacheKey: string, cacheConfig: ICacheC
           cacheConfig.shouldCacheDecider(response)
         ) {
           if (
-            !cacheConfig.maxCacheCount ||
-            cacheConfig.maxCacheCount === 1 ||
-            (cacheConfig.maxCacheCount &&
-              cacheConfig.maxCacheCount < cachePairs.length + 1)
+            !(cacheConfig.maxCacheCount || GlobalCacheConfig.maxCacheCount) ||
+            (cacheConfig.maxCacheCount || GlobalCacheConfig.maxCacheCount) === 1 ||
+            ((cacheConfig.maxCacheCount || GlobalCacheConfig.maxCacheCount) &&
+              (cacheConfig.maxCacheCount || GlobalCacheConfig.maxCacheCount) < cachePairs.length + 1)
           ) {
             storageStrategy.removeAtIndex(0, cacheKey);
           }
           storageStrategy.add({
             parameters: cacheParameters,
             response,
-            created: cacheConfig.maxAge ? new Date() : null
+            created: (cacheConfig.maxAge || GlobalCacheConfig.maxAge) ? new Date() : null
           }, cacheKey);
         }
 

--- a/specs/cat.ts
+++ b/specs/cat.ts
@@ -1,0 +1,4 @@
+export class Cat {
+  meow(phrase: string) { return this.name + ' says ' + phrase };
+  name: string;
+}

--- a/specs/observable-cacheable.decorator.spec.ts
+++ b/specs/observable-cacheable.decorator.spec.ts
@@ -8,182 +8,167 @@ import { mapTo } from 'rxjs/operators';
 import { GlobalCacheConfig } from '../common';
 import { DOMStorageStrategy } from '../common/DOMStorageStrategy';
 import { InMemoryStorageStrategy } from '../common/InMemoryStorageStrategy';
-
-const strategies = [null, DOMStorageStrategy];
+import { IService } from './service.interface';
+import { Cat } from './cat';
+const strategies: any[] = [
+  null,
+  DOMStorageStrategy
+];
 strategies.forEach(s => {
   if (s) {
     GlobalCacheConfig.storageStrategy = s;
   }
-  const cacheBusterNotifier = new Subject();
-  class Cat {
-    meow(phrase: string) { return this.name + ' says ' + phrase };
-    name: string;
-  }
-  class Service {
-    mockServiceCall(parameter: any) {
-      return timer(1000).pipe(mapTo({ payload: parameter }));
-    }
-    mockSaveServiceCall() {
-      return timer(1000).pipe(mapTo('SAVED'));
-    }
-
-    mockServiceCallWithMultipleParameters(parameter1: any, parameter2: any) {
-      return timer(1000).pipe(mapTo({ payload: [parameter1, parameter2] }));
-    }
-
-    @Cacheable()
-    getData(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable()
-    getDataWithParamsObj(parameter: any) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable()
-    getDataAndReturnCachedStream(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable({
-      async: true
-    })
-    getDataAsync(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable({
-      maxAge: 7500
-    })
-    getDataWithExpiration(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable({
-      maxAge: 7500,
-      slidingExpiration: true
-    })
-    getDataWithSlidingExpiration(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable({
-      maxCacheCount: 5
-    })
-    getDataWithMaxCacheCount(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable({
-      maxAge: 7500,
-      maxCacheCount: 5
-    })
-    getDataWithMaxCacheCountAndExpiration(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable({
-      maxAge: 7500,
-      maxCacheCount: 5,
-      slidingExpiration: true
-    })
-    getDataWithMaxCacheCountAndSlidingExpiration(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable({
-      cacheResolver: (_oldParameters, newParameters) => {
-        return newParameters.find((param: any) => !!param.straightToLastCache);
-      }
-    })
-    getDataWithCustomCacheResolver(
-      parameter: string,
-      _cacheRerouterParameter?: { straightToLastCache: boolean }
-    ) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable({
-      cacheHasher: (_parameters) => _parameters[0] * 2,
-      cacheResolver: (oldParameter, newParameter) => {
-        return newParameter > 5
-      }
-    })
-    getDataWithCustomCacheResolverAndHasher(
-      parameter: number
-    ) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable()
-    getWithAComplexType(
-      parameter: Cat
-    ) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable({
-      shouldCacheDecider: (response: { payload: string }) => {
-        return response.payload === 'test';
-      }
-    })
-    getDataWithCustomCacheDecider(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @CacheBuster({
-      cacheBusterNotifier: cacheBusterNotifier
-    })
-    saveDataAndCacheBust() {
-      return this.mockSaveServiceCall();
-    }
-
-    @Cacheable({
-      cacheBusterObserver: cacheBusterNotifier.asObservable()
-    })
-    getDataWithCacheBusting(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable()
-    getDataWithUndefinedParameter(parameter: string = '') {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable()
-    getDataWithMultipleUndefinedParameters(parameter: string = 'Parameter1', parameter1: string = 'Parameter2') {
-      return this.mockServiceCallWithMultipleParameters(parameter, parameter1);
-    }
-
-    @Cacheable()
-    getData1(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable()
-    getData2(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable()
-    getData3(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @Cacheable({
-      maxAge: 7500,
-      slidingExpiration: true,
-      storageStrategy: InMemoryStorageStrategy
-    })
-    getDateWithCustomStorageStrategyProvided(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-  }
   describe('CacheableDecorator', () => {
-    let service: Service = null;
+    let service: IService<Observable<any>> = null;
     let mockServiceCallSpy: jasmine.Spy = null;
     beforeEach(() => {
+      const cacheBusterNotifier = new Subject();
+      class Service {
+        mockServiceCall(parameter: any) {
+          return timer(1000).pipe(mapTo({ payload: parameter }));
+        }
+        mockSaveServiceCall() {
+          return timer(1000).pipe(mapTo('SAVED'));
+        }
+
+        mockServiceCallWithMultipleParameters(parameter1: any, parameter2: any) {
+          return timer(1000).pipe(mapTo({ payload: [parameter1, parameter2] }));
+        }
+
+        @Cacheable()
+        getData(parameter: string) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable()
+        getDataWithParamsObj(parameter: any) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable()
+        getDataAndReturnCachedStream(parameter: string) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable({
+          async: true
+        })
+        getDataAsync(parameter: string) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable({
+          maxAge: 7500
+        })
+        getDataWithExpiration(parameter: string) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable({
+          maxAge: 7500,
+          slidingExpiration: true
+        })
+        getDataWithSlidingExpiration(parameter: string) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable({
+          maxCacheCount: 5
+        })
+        getDataWithMaxCacheCount(parameter: string) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable({
+          maxAge: 7500,
+          maxCacheCount: 5
+        })
+        getDataWithMaxCacheCountAndExpiration(parameter: string) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable({
+          maxAge: 7500,
+          maxCacheCount: 5,
+          slidingExpiration: true
+        })
+        getDataWithMaxCacheCountAndSlidingExpiration(parameter: string) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable({
+          cacheResolver: (_oldParameters, newParameters) => {
+            return newParameters.find((param: any) => !!param.straightToLastCache);
+          }
+        })
+        getDataWithCustomCacheResolver(
+          parameter: string,
+          _cacheRerouterParameter?: { straightToLastCache: boolean }
+        ) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable({
+          cacheHasher: (_parameters) => _parameters[0] * 2,
+          cacheResolver: (oldParameter, newParameter) => {
+            return newParameter > 5
+          }
+        })
+        getDataWithCustomCacheResolverAndHasher(
+          parameter: number
+        ) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable()
+        getWithAComplexType(
+          parameter: Cat
+        ) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable({
+          shouldCacheDecider: (response: { payload: string }) => {
+            return response.payload === 'test';
+          }
+        })
+        getDataWithCustomCacheDecider(parameter: string) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @CacheBuster({
+          cacheBusterNotifier: cacheBusterNotifier
+        })
+        saveDataAndCacheBust() {
+          return this.mockSaveServiceCall();
+        }
+
+        @Cacheable({
+          cacheBusterObserver: cacheBusterNotifier.asObservable()
+        })
+        getDataWithCacheBusting(parameter: string) {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable()
+        getDataWithUndefinedParameter(parameter: string = '') {
+          return this.mockServiceCall(parameter);
+        }
+
+        @Cacheable()
+        getDataWithMultipleUndefinedParameters(parameter: string = 'Parameter1', parameter1: string = 'Parameter2') {
+          return this.mockServiceCallWithMultipleParameters(parameter, parameter1);
+        }
+
+        @Cacheable({
+          maxAge: 7500,
+          slidingExpiration: true,
+          storageStrategy: InMemoryStorageStrategy
+        })
+        getDateWithCustomStorageStrategyProvided(parameter: string) {
+          return this.mockServiceCall(parameter);
+        }
+      }
       jasmine.clock().install();
       service = new Service();
       mockServiceCallSpy = spyOn(service, 'mockServiceCall').and.callThrough();
@@ -837,38 +822,38 @@ strategies.forEach(s => {
       /**
        * call the first method and cache it
        */
-      service.getData1('test1');
+      service.getData('test1');
       const asyncFreshData1 = _timedStreamAsyncAwait(
-        service.getData1('test1'),
+        service.getData('test1'),
         1000
       );
       expect(asyncFreshData1).toEqual({ payload: 'test1' });
-      const cachedResponse1 = _timedStreamAsyncAwait(service.getData1('test1'));
+      const cachedResponse1 = _timedStreamAsyncAwait(service.getData('test1'));
       expect(cachedResponse1).toEqual({ payload: 'test1' });
       /**
-       * even though we called getData1 twice, this should only be called once
+       * even though we called getData twice, this should only be called once
        * since the second call went straight to the cache
        */
       expect(mockServiceCallSpy).toHaveBeenCalledTimes(1);
 
-      service.getData2('test2');
+      service.getData('test2');
       const asyncFreshData2 = _timedStreamAsyncAwait(
-        service.getData2('test2'),
+        service.getData('test2'),
         1000
       );
       expect(asyncFreshData2).toEqual({ payload: 'test2' });
-      const cachedResponse2 = _timedStreamAsyncAwait(service.getData2('test2'));
+      const cachedResponse2 = _timedStreamAsyncAwait(service.getData('test2'));
       expect(cachedResponse2).toEqual({ payload: 'test2' });
       expect(mockServiceCallSpy).toHaveBeenCalledTimes(2);
 
 
-      service.getData3('test3');
+      service.getData('test3');
       const asyncFreshData3 = _timedStreamAsyncAwait(
-        service.getData3('test3'),
+        service.getData('test3'),
         1000
       );
       expect(asyncFreshData3).toEqual({ payload: 'test3' });
-      const cachedResponse3 = _timedStreamAsyncAwait(service.getData3('test3'));
+      const cachedResponse3 = _timedStreamAsyncAwait(service.getData('test3'));
       expect(cachedResponse3).toEqual({ payload: 'test3' });
       expect(mockServiceCallSpy).toHaveBeenCalledTimes(3);
 
@@ -878,15 +863,15 @@ strategies.forEach(s => {
       globalCacheBusterNotifier.next();
 
       _timedStreamAsyncAwait(
-        service.getData1('test1'),
+        service.getData('test1'),
         1000
       );
       _timedStreamAsyncAwait(
-        service.getData2('test2'),
+        service.getData('test2'),
         1000
       );
       _timedStreamAsyncAwait(
-        service.getData3('test3'),
+        service.getData('test3'),
         1000
       );
 
@@ -1013,6 +998,205 @@ strategies.forEach(s => {
       expect(removeAtIndexSpy).toHaveBeenCalledTimes(2);
       expect(removeAllSpy).toHaveBeenCalled();
     })
+
+    it('use the maxAge and slidingExpiration from the GlobalCacheConfig', () => {
+      GlobalCacheConfig.maxAge = 7500;
+      GlobalCacheConfig.slidingExpiration = true;
+      jasmine.clock().mockDate();
+      const asyncFreshData = _timedStreamAsyncAwait(
+        service.getData('test'),
+        1000
+      );
+      expect(asyncFreshData).toEqual({ payload: 'test' });
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(1);
+
+      const cachedResponse = _timedStreamAsyncAwait(
+        service.getData('test')
+      );
+      expect(cachedResponse).toEqual({ payload: 'test' });
+      /**
+       * call count should still be one, since we rerouted to cache, instead of service call
+       */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(1);
+
+      /**
+       * travel through 3000ms of time
+       */
+      jasmine.clock().tick(3000);
+      /**
+       * calling the method again should renew expiration for 7500 more milliseconds
+       */
+      service.getData('test').subscribe();
+      jasmine.clock().tick(4501);
+
+      /**
+       * this should have returned null, if the cache didnt renew
+       */
+
+      const cachedResponse2 = _timedStreamAsyncAwait(
+        service.getData('test')
+      );
+      expect(cachedResponse2).toEqual({ payload: 'test' });
+      /**
+       * call count is still one, because we renewed the cache 4501ms ago
+       */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(1);
+
+      /**
+       * expire cache, shouldn't renew since 7501 ms have ellapsed
+       */
+      jasmine.clock().tick(7501);
+
+      const cachedResponse3 = _timedStreamAsyncAwait(
+        service.getData('test')
+      );
+      /**
+       * cached has expired, request hasn't returned yet but still - the service was called
+       */
+      expect(cachedResponse3).toEqual(null);
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(2);
+      GlobalCacheConfig.maxAge = undefined;
+      GlobalCacheConfig.slidingExpiration;
+    });
+
+    it('use the maxCacheCount from the GlobalCacheConfig', () => {
+      GlobalCacheConfig.maxCacheCount = 5;
+      /**
+       * call the same endpoint with 5 different parameters and cache all 5 responses, based on the maxCacheCount parameter
+       */
+      const parameters = ['test1', 'test2', 'test3', 'test4', 'test5'];
+      parameters.forEach(async param =>
+        _timedStreamAsyncAwait(service.getData(param), 1000)
+      );
+      /**
+       * data for all endpoints should be available through cache by now
+       */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(5);
+
+      const cachedResponse = _timedStreamAsyncAwait(
+        service.getData('test1')
+      );
+      expect(cachedResponse).toEqual({ payload: 'test1' });
+      /** call count still 5 */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(5);
+
+      /**
+       * this should return a maximum of 5 different cached responses
+       */
+      const cachedResponseAll = _timedStreamAsyncAwait(
+        forkJoin(parameters.map(param => service.getData(param)))
+      );
+
+      expect(cachedResponseAll).toEqual([
+        { payload: 'test1' },
+        { payload: 'test2' },
+        { payload: 'test3' },
+        { payload: 'test4' },
+        { payload: 'test5' }
+      ]);
+      /** call count still 5 */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(5);
+
+      const asyncData = _timedStreamAsyncAwait(
+        service.getData('test6'),
+        1000
+      );
+
+      expect(asyncData).toEqual({ payload: 'test6' });
+      /** call count incremented by one */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(6);
+
+      /**
+       * by now the response for test6 should be cached and the one for test1 should be free for GC..
+       */
+      const newParameters = ['test2', 'test3', 'test4', 'test5', 'test6'];
+
+      /**
+       * this should return a maximum of 5 different cached responses, with the latest one in the end
+       */
+      const cachedResponseAll2 = _timedStreamAsyncAwait(
+        forkJoin(
+          newParameters.map(param => service.getData(param))
+        ),
+        1000
+      );
+      expect(cachedResponseAll2).toEqual([
+        { payload: 'test2' },
+        { payload: 'test3' },
+        { payload: 'test4' },
+        { payload: 'test5' },
+        { payload: 'test6' }
+      ]);
+
+      /** no service calls will be made, since we have all the responses still cached even after 1s (1000ms) */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(6);
+      /**
+       * fetch and cache the test7 response
+       */
+      const nonCachedResponse = _timedStreamAsyncAwait(
+        service.getData('test7'),
+        1000
+      );
+      expect(nonCachedResponse).toEqual({ payload: 'test7' });
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(7);
+
+      /**
+       * since the cached response for 'test2' was now removed from cache by 'test7', it shouldn't be available in cache
+       */
+      const cachedResponse2 = _timedStreamAsyncAwait(
+        service.getData('test2')
+      );
+      expect(cachedResponse2).toEqual(null);
+      /**
+       * service call is made anyway
+       */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(8);
+
+      GlobalCacheConfig.maxCacheCount = undefined;
+    });
+    it('use the maxAge from the GlobalCacheConfig', () => {
+      GlobalCacheConfig.maxAge = 10000;
+      jasmine.clock().mockDate();
+
+      const asyncFreshData = _timedStreamAsyncAwait(
+        service.getData('test'),
+        1000
+      );
+
+      expect(asyncFreshData).toEqual({ payload: 'test' });
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(1);
+
+      const cachedResponse = _timedStreamAsyncAwait(
+        service.getData('test')
+      );
+      /**
+       * service shouldn't be called and we should route directly to cache
+       */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(1);
+      expect(cachedResponse).toEqual({ payload: 'test' });
+
+      /**
+       * progress in time for 10001 ms, e.g - one millisecond after the maxAge would expire
+       */
+      jasmine.clock().tick(10001);
+
+      /**
+       * no cache anymore, bail out to service call
+       */
+      const cachedResponse2 = _timedStreamAsyncAwait(
+        service.getData('test')
+      );
+      expect(cachedResponse2).toEqual(null);
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(2);
+
+      let asyncFreshDataAfterCacheBust = null;
+      service.getData('test').subscribe(data => {
+        asyncFreshDataAfterCacheBust = data;
+      });
+      jasmine.clock().tick(1000);
+      expect(asyncFreshDataAfterCacheBust).toEqual({ payload: 'test' });
+      GlobalCacheConfig.maxAge = undefined;
+    });
   });
 
   function _timedStreamAsyncAwait(stream$: Observable<any>, skipTime?: number): any {

--- a/specs/promise-cacheable.decorator.spec.ts
+++ b/specs/promise-cacheable.decorator.spec.ts
@@ -6,8 +6,9 @@ import { GlobalCacheConfig, ICachePair } from '../common';
 import { DOMStorageStrategy } from '../common/DOMStorageStrategy';
 import { InMemoryStorageStrategy } from '../common/InMemoryStorageStrategy';
 import { IAsyncStorageStrategy } from 'common/IAsyncStorageStrategy';
+import { IService } from './service.interface';
+import { Cat } from './cat';
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
-
 class AsyncStorageStrategy extends IAsyncStorageStrategy {
   private cachePairs: Array<ICachePair<any>> = [];
 
@@ -42,179 +43,160 @@ strategies.forEach(s => {
   if (s) {
     GlobalCacheConfig.storageStrategy = s;
   }
-  class Cat {
-    meow(phrase: string) { return this.name + ' says ' + phrase };
-    name: string;
-  }
-  class Service {
-    mockServiceCall(parameter: any) {
-      return new Promise<any>(resolve => {
-        setTimeout(() => {
-          resolve({ payload: parameter });
-        }, 300);
-      });
-    }
-    mockSaveServiceCall() {
-      return new Promise(resolve => {
-        setTimeout(() => {
-          resolve('SAVED');
-        }, 300);
-      });
-    }
-
-    mockServiceCallWithMultipleParameters(parameter1: any, parameter2: any) {
-      return new Promise(resolve => {
-        setTimeout(() => {
-          resolve({ payload: [parameter1, parameter2] });
-        }, 300);
-      });
-    }
-
-    @PCacheable()
-    getData(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable()
-    getDataWithParamsObj(parameter: any) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable()
-    getDataAndReturnCachedStream(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable({
-      maxAge: 400
-    })
-    getDataWithExpiration(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable({
-      maxAge: 400,
-      slidingExpiration: true
-    })
-    getDataWithSlidingExpiration(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable({
-      maxCacheCount: 5
-    })
-    getDataWithMaxCacheCount(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable({
-      maxAge: 400,
-      maxCacheCount: 5
-    })
-    getDataWithMaxCacheCountAndExpiration(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable({
-      maxAge: 400,
-      maxCacheCount: 5,
-      slidingExpiration: true
-    })
-    getDataWithMaxCacheCountAndSlidingExpiration(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable({
-      cacheResolver: (_oldParameters, newParameters) => {
-        return newParameters.find((param: any) => !!param.straightToLastCache);
-      }
-    })
-    getDataWithCustomCacheResolver(
-      parameter: string,
-      _cacheRerouterParameter?: { straightToLastCache: boolean }
-    ) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable({
-      cacheHasher: (_parameters) => _parameters[0] * 2,
-      cacheResolver: (oldParameter, newParameter) => {
-        return newParameter > 5
-      }
-    })
-    getDataWithCustomCacheResolverAndHasher(
-      parameter: number
-    ) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable()
-    getWithAComplexType(
-      parameter: Cat
-    ) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable({
-      shouldCacheDecider: (response: { payload: string }) => {
-        return response.payload === 'test';
-      }
-    })
-    getDataWithCustomCacheDecider(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheBuster({
-      cacheBusterNotifier: cacheBusterNotifier
-    })
-    saveDataAndCacheBust() {
-      return this.mockSaveServiceCall();
-    }
-
-    @PCacheable({
-      cacheBusterObserver: cacheBusterNotifier.asObservable()
-    })
-    getDataWithCacheBusting(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable()
-    getDataWithUndefinedParameter(parameter: string = '') {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable()
-    getDataWithMultipleUndefinedParameters(parameter: string = 'Parameter1', parameter1: string = 'Parameter2') {
-      return this.mockServiceCallWithMultipleParameters(parameter, parameter1);
-    }
-    @PCacheable()
-    getData1(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable()
-    getData2(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable()
-    getData3(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-
-    @PCacheable({
-      maxAge: 400,
-      slidingExpiration: true,
-      storageStrategy: InMemoryStorageStrategy
-    })
-    getDateWithCustomStorageStrategyProvided(parameter: string) {
-      return this.mockServiceCall(parameter);
-    }
-  }
 
   describe('PCacheableDecorator', () => {
-    let service: Service = null;
+    let service: IService<Promise<any>> = null;
     let mockServiceCallSpy: jasmine.Spy = null;
+    class Service {
+      mockServiceCall(parameter: any) {
+        return new Promise<any>(resolve => {
+          setTimeout(() => {
+            resolve({ payload: parameter });
+          }, 300);
+        });
+      }
+      mockSaveServiceCall() {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            resolve('SAVED');
+          }, 300);
+        });
+      }
+
+      mockServiceCallWithMultipleParameters(parameter1: any, parameter2: any) {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            resolve({ payload: [parameter1, parameter2] });
+          }, 300);
+        });
+      }
+
+      @PCacheable()
+      getData(parameter: string) {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheable()
+      getDataWithParamsObj(parameter: any) {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheable()
+      getDataAndReturnCachedStream(parameter: string) {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheable({
+        maxAge: 400
+      })
+      getDataWithExpiration(parameter: string) {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheable({
+        maxAge: 400,
+        slidingExpiration: true
+      })
+      getDataWithSlidingExpiration(parameter: string) {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheable({
+        maxCacheCount: 5
+      })
+      getDataWithMaxCacheCount(parameter: string) {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheable({
+        maxAge: 400,
+        maxCacheCount: 5
+      })
+      getDataWithMaxCacheCountAndExpiration(parameter: string) {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheable({
+        maxAge: 400,
+        maxCacheCount: 5,
+        slidingExpiration: true
+      })
+      getDataWithMaxCacheCountAndSlidingExpiration(parameter: string) {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheable({
+        cacheResolver: (_oldParameters, newParameters) => {
+          return newParameters.find((param: any) => !!param.straightToLastCache);
+        }
+      })
+      getDataWithCustomCacheResolver(
+        parameter: string,
+        _cacheRerouterParameter?: { straightToLastCache: boolean }
+      ) {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheable({
+        cacheHasher: (_parameters) => _parameters[0] * 2,
+        cacheResolver: (oldParameter, newParameter) => {
+          return newParameter > 5
+        }
+      })
+      getDataWithCustomCacheResolverAndHasher(
+        parameter: number
+      ) {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheable()
+      getWithAComplexType(
+        parameter: Cat
+      ) {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheable({
+        shouldCacheDecider: (response: { payload: string }) => {
+          return response.payload === 'test';
+        }
+      })
+      getDataWithCustomCacheDecider(parameter: string) {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheBuster({
+        cacheBusterNotifier: cacheBusterNotifier
+      })
+      saveDataAndCacheBust() {
+        return this.mockSaveServiceCall();
+      }
+
+      @PCacheable({
+        cacheBusterObserver: cacheBusterNotifier.asObservable()
+      })
+      getDataWithCacheBusting(parameter: string) {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheable()
+      getDataWithUndefinedParameter(parameter: string = '') {
+        return this.mockServiceCall(parameter);
+      }
+
+      @PCacheable()
+      getDataWithMultipleUndefinedParameters(parameter: string = 'Parameter1', parameter1: string = 'Parameter2') {
+        return this.mockServiceCallWithMultipleParameters(parameter, parameter1);
+      }
+      @PCacheable({
+        maxAge: 400,
+        slidingExpiration: true,
+        storageStrategy: InMemoryStorageStrategy
+      })
+      getDateWithCustomStorageStrategyProvided(parameter: string) {
+        return this.mockServiceCall(parameter);
+      }
+    }
     beforeEach(() => {
       service = new Service();
       mockServiceCallSpy = spyOn(service, 'mockServiceCall').and.callThrough();
@@ -552,34 +534,34 @@ strategies.forEach(s => {
       /**
        * call the first method and cache it
        */
-      service.getData1('test1');
+      service.getData('test1');
       const asyncFreshData1 = await (
-        service.getData1('test1')
+        service.getData('test1')
       );
 
       expect(asyncFreshData1).toEqual({ payload: 'test1' });
-      const cachedResponse1 = await (service.getData1('test1'));
+      const cachedResponse1 = await (service.getData('test1'));
       expect(cachedResponse1).toEqual({ payload: 'test1' });
       /**
-       * even though we called getData1 twice, this should only be called once
+       * even though we called getData twice, this should only be called once
        * since the second call went straight to the cache
        */
       expect(mockServiceCallSpy).toHaveBeenCalledTimes(1);
 
-      service.getData2('test2');
+      service.getData('test2');
       const asyncFreshData2 = await (
-        service.getData2('test2')
+        service.getData('test2')
       );
 
       expect(asyncFreshData2).toEqual({ payload: 'test2' });
-      const cachedResponse2 = await (service.getData2('test2'));
+      const cachedResponse2 = await (service.getData('test2'));
       expect(cachedResponse2).toEqual({ payload: 'test2' });
       expect(mockServiceCallSpy).toHaveBeenCalledTimes(2);
 
-      service.getData3('test3');
-      const asyncFreshData3 = await (service.getData3('test3'));
+      service.getData('test3');
+      const asyncFreshData3 = await (service.getData('test3'));
       expect(asyncFreshData3).toEqual({ payload: 'test3' });
-      const cachedResponse3 = await (service.getData3('test3'));
+      const cachedResponse3 = await (service.getData('test3'));
       expect(cachedResponse3).toEqual({ payload: 'test3' });
       expect(mockServiceCallSpy).toHaveBeenCalledTimes(3);
 
@@ -588,9 +570,9 @@ strategies.forEach(s => {
        */
       promiseGlobalCacheBusterNotifier.next();
 
-      await (service.getData1('test1'));
-      await (service.getData2('test2'));
-      await (service.getData3('test3'));
+      await (service.getData('test1'));
+      await (service.getData('test2'));
+      await (service.getData('test3'));
 
       /**
        * if we didn't bust the cache, this would've been 3
@@ -711,6 +693,141 @@ strategies.forEach(s => {
       expect(service.mockServiceCall).toHaveBeenCalledWith(complexObject);
       // object method would not exist if we have mutated the parameter through the DEFAULT_CACHE_RESOLVER
       expect(response.payload.meow("I am hungry!")).toBe("Felix says I am hungry!")
+    });
+
+    it('use the maxAge and slidingExpiration from the GlobalCacheConfig', async done => {
+      GlobalCacheConfig.maxAge = 400;
+      GlobalCacheConfig.slidingExpiration = true;
+
+      const asyncFreshData = await service.getData('test');
+      expect(asyncFreshData).toEqual({ payload: 'test' });
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(1);
+
+      const cachedResponse = await service.getData('test');
+      expect(cachedResponse).toEqual({ payload: 'test' });
+      /**
+       * call count should still be one, since we rerouted to cache, instead of service call
+       */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(1);
+
+      setTimeout(async () => {
+        await service.getData('test');
+        expect(mockServiceCallSpy).toHaveBeenCalledTimes(1);
+        setTimeout(async () => {
+          await service.getData('test');
+          expect(mockServiceCallSpy).toHaveBeenCalledTimes(2);
+          done();
+          GlobalCacheConfig.maxAge = undefined;
+          GlobalCacheConfig.slidingExpiration;
+        }, 500);
+      }, 200);
+
+    });
+
+    it('use the maxCacheCount from the GlobalCacheConfig', async () => {
+      GlobalCacheConfig.maxCacheCount = 5;
+      /**
+       * call the same endpoint with 5 different parameters and cache all 5 responses, based on the maxCacheCount parameter
+       */
+      const parameters = ['test1', 'test2', 'test3', 'test4', 'test5'];
+      await Promise.all(parameters.map(
+        param => (service.getDataWithMaxCacheCount(param))
+      ))
+      /**
+       * data for all endpoints should be available through cache by now
+       */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(5);
+
+      const cachedResponse = await service.getDataWithMaxCacheCount('test1');
+      expect(cachedResponse).toEqual({ payload: 'test1' });
+      /** call count still 5 */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(5);
+
+      /**
+       * this should return a maximum of 5 different cached responses
+       */
+      const cachedResponseAll = await Promise.all(
+        parameters.map(param => service.getDataWithMaxCacheCount(param))
+      );
+
+      expect(cachedResponseAll).toEqual([
+        { payload: 'test1' },
+        { payload: 'test2' },
+        { payload: 'test3' },
+        { payload: 'test4' },
+        { payload: 'test5' }
+      ]);
+      /** call count still 5 */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(5);
+
+      const asyncData = await service.getDataWithMaxCacheCount('test6');
+
+      expect(asyncData).toEqual({ payload: 'test6' });
+      /** call count incremented by one */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(6);
+
+      /**
+       * by now the response for test6 should be cached and the one for test1 should be free for GC..
+       */
+      const newParameters = ['test2', 'test3', 'test4', 'test5', 'test6'];
+
+      /**
+       * this should return a maximum of 5 different cached responses, with the latest one in the end
+       */
+      const cachedResponseAll2 = await Promise.all(
+        newParameters.map(param => service.getDataWithMaxCacheCount(param))
+      );
+
+      expect(cachedResponseAll2).toEqual([
+        { payload: 'test2' },
+        { payload: 'test3' },
+        { payload: 'test4' },
+        { payload: 'test5' },
+        { payload: 'test6' }
+      ]);
+
+      /** no service calls will be made, since we have all the responses still cached even after 1s (1000ms) */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(6);
+      /**
+       * fetch and cache the test7 response
+       */
+      const nonCachedResponse = await service.getDataWithMaxCacheCount('test7');
+      expect(nonCachedResponse).toEqual({ payload: 'test7' });
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(7);
+
+      /**
+       * since the cached response for 'test2' was now removed from cache by 'test7',
+       */
+      await service.getDataWithMaxCacheCount('test2');
+      /**
+       * test2 is not in cache anymore and a service call will be made
+       */
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(8);
+      GlobalCacheConfig.maxCacheCount = undefined;
+    });
+
+
+    it('use the maxAge from the GlobalCacheConfig', async done => {
+      GlobalCacheConfig.maxAge = 10000;
+      const asyncFreshData = await service.getDataWithExpiration('test');
+
+      expect(asyncFreshData).toEqual({ payload: 'test' });
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(1);
+
+      const cachedResponse = await service.getDataWithExpiration('test');
+      expect(cachedResponse).toEqual({ payload: 'test' });
+      expect(mockServiceCallSpy).toHaveBeenCalledTimes(1);
+
+      setTimeout(async () => {
+        /**
+         * after 500ms the cache would've expired and we will bail to the data source
+         */
+        await service.getDataWithExpiration('test');
+        expect(mockServiceCallSpy).toHaveBeenCalledTimes(2);
+        GlobalCacheConfig.maxAge = undefined;
+        done();
+      }, 500);
+
     });
   });
 });

--- a/specs/service.interface.ts
+++ b/specs/service.interface.ts
@@ -1,0 +1,31 @@
+import { Cat } from './cat';
+export interface IService<T> {
+  mockServiceCall(parameter: any): T;
+  mockSaveServiceCall(): T;
+  mockServiceCallWithMultipleParameters(parameter1: any, parameter2: any): T;
+  getData(parameter: string): T;
+  getDataWithParamsObj(parameter: any): T;
+  getDataAndReturnCachedStream(parameter: string): T;
+  getDataWithExpiration(parameter: string): T;
+  getDataWithSlidingExpiration(parameter: string): T;
+  getDataWithMaxCacheCount(parameter: string): T;
+  getDataWithMaxCacheCountAndExpiration(parameter: string): T;
+  getDataWithMaxCacheCountAndSlidingExpiration(parameter: string): T;
+  getDataWithCustomCacheResolver(
+    parameter: string,
+    _cacheRerouterParameter?: { straightToLastCache: boolean }
+  ): T;
+  getDataWithCustomCacheResolverAndHasher(
+    parameter: number
+  ): T;
+  getWithAComplexType(
+    parameter: Cat
+  ): T;
+  getDataWithCustomCacheDecider(parameter: string): T;
+  saveDataAndCacheBust(): T;
+  getDataWithCacheBusting(parameter: string): T;
+  getDataWithUndefinedParameter(parameter?: string): T;
+  getDataWithMultipleUndefinedParameters(parameter: string, parameter1: string): T;
+  getDateWithCustomStorageStrategyProvided(parameter: string): T;
+  getDataAsync?(parameter: string): T;
+}


### PR DESCRIPTION
Fixes #57 
Based on the discussion in #57, we figured that it could be nice to extend the global cache config to allow for options like:
`maxAge`,
`maxCacheCount`
and `slidingExpiration`
@stnor please take a look